### PR TITLE
Develop

### DIFF
--- a/mklink.bat
+++ b/mklink.bat
@@ -2,3 +2,8 @@ rem make symbolic links for vim settings
 rem run "rm -rf symbliclink" when removing symbliclink (do not add "\" to the end of the folder)
 mklink %HOMEPATH%\_vimrc %HOMEPATH%\dotfiles\.vimrc
 mklink /D %HOMEPATH%\vimfiles\colors %HOMEPATH%\dotfiles\colors
+
+rem install Vundle.vim if not installed
+if exist "%HOMEPATH%\bundle\Vundle.vim" (
+  git clone https://github.com/VundleVim/Vundle.vim %HOMEPATH%\bundle\Vundle.vim 
+)

--- a/mklink.bat
+++ b/mklink.bat
@@ -6,6 +6,8 @@ mklink /D %HOMEPATH%\vimfiles\colors %HOMEPATH%\dotfiles\colors
 @rem install Vundle.vim if not installed
 @rem set VUNDLE_INSTALL_PATH = %HOMEPATH%\vimfiles\bundle\Vundle.vim
 @rem echo %VUNDLE_INSTALL_PATH%
-if not exist %HOMEPATH%\vimfiles\bundle\Vundle.vim (
-  git clone https://github.com/VundleVim/Vundle.vim.git %HOMEPATH%\vimfiles\bundle\Vundle.vim 
+if exist %HOMEPATH%\vimfiles\bundle\Vundle.vim (
+  rmdir /s /q %HOMEPATH%\vimfiles\bundle\Vundle.vim
 )
+git clone https://github.com/VundleVim/Vundle.vim.git %HOMEPATH%\vimfiles\bundle\Vundle.vim 
+

--- a/mklink.bat
+++ b/mklink.bat
@@ -1,9 +1,11 @@
-rem make symbolic links for vim settings
-rem run "rm -rf symbliclink" when removing symbliclink (do not add "\" to the end of the folder)
+@rem make symbolic links for vim settings
+@rem run "rm -rf symbliclink" when removing symbliclink (do not add "\" to the end of the folder)
 mklink %HOMEPATH%\_vimrc %HOMEPATH%\dotfiles\.vimrc
 mklink /D %HOMEPATH%\vimfiles\colors %HOMEPATH%\dotfiles\colors
 
-rem install Vundle.vim if not installed
-if exist "%HOMEPATH%\bundle\Vundle.vim" (
-  git clone https://github.com/VundleVim/Vundle.vim %HOMEPATH%\bundle\Vundle.vim 
+@rem install Vundle.vim if not installed
+@rem set VUNDLE_INSTALL_PATH = %HOMEPATH%\vimfiles\bundle\Vundle.vim
+@rem echo %VUNDLE_INSTALL_PATH%
+if not exist %HOMEPATH%\vimfiles\bundle\Vundle.vim (
+  git clone https://github.com/VundleVim/Vundle.vim.git %HOMEPATH%\vimfiles\bundle\Vundle.vim 
 )

--- a/mklink_linux.sh
+++ b/mklink_linux.sh
@@ -7,9 +7,10 @@ if [ ! -e ~/.vim ]; then
 fi
 
 # install Vundle.vim
-if [ ! -e ~/.vim/bundle/Vundle.vim ]; then
-  git clone https://github.com/VundleVim/Vundle.vim ~/.vim/bundle/Vundle.vim
+if [ -e ~/.vim/bundle/Vundle.vim ]; then
+  rm -rf ~/.vim/bundle/Vundle.vim
 fi
+git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
 
 ln -sf ~/dotfiles/colors ~/.vim/colors
 ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf

--- a/mklink_linux.sh
+++ b/mklink_linux.sh
@@ -5,6 +5,11 @@ ln -sf ~/dotfiles/.vimrc ~/.vimrc
 if [ ! -e ~/.vim ]; then
   mkdir ~/.vim
 fi
-ln -sf ~/dotfiles/colors ~/.vim/colors
 
+# install Vundle.vim
+if [ ! -e ~/.vim/bundle/Vundle.vim ]; then
+  git clone https://github.com/VundleVim/Vundle.vim ~/.vim/bundle/Vundle.vim
+fi
+
+ln -sf ~/dotfiles/colors ~/.vim/colors
 ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf


### PR DESCRIPTION
[mklink_~実行後にVundle.vimがないエラーが出る](https://github.com/ry-2456/dotfiles/issues/4)の対応